### PR TITLE
Fix item image placeholder on the api side

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -87,6 +87,7 @@ router.get("/", auth.optional, function(req, res, next) {
           items: await Promise.all(
             items.map(async function(item) {
               item.seller = await User.findById(item.seller);
+              item.image = item.image.length !== 0 ? item.image : '/placeholder.png'
               return item.toJSONFor(user);
             })
           ),

--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -144,6 +144,10 @@ router.post("/", auth.required, function(req, res, next) {
         return res.sendStatus(401);
       }
 
+      if (req.body.item.image === undefined || req.body.item.image.length === 0) {
+          req.body.item.image = '/placeholder.png';
+      }
+
       var item = new Item(req.body.item);
 
       item.seller = user;
@@ -183,11 +187,7 @@ router.put("/:item", auth.required, function(req, res, next) {
       }
 
       if (typeof req.body.item.image !== "undefined") {
-        if (req.body.item.image.length === 0) {
-          req.item.image = '/placeholder.png'
-        } else {
-          req.item.image = req.body.item.image;
-        }
+        req.item.image = req.body.item.image;
       }
 
       if (typeof req.body.item.tagList !== "undefined") {

--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -87,7 +87,6 @@ router.get("/", auth.optional, function(req, res, next) {
           items: await Promise.all(
             items.map(async function(item) {
               item.seller = await User.findById(item.seller);
-              item.image = item.image.length !== 0 ? item.image : '/placeholder.png'
               return item.toJSONFor(user);
             })
           ),
@@ -184,7 +183,11 @@ router.put("/:item", auth.required, function(req, res, next) {
       }
 
       if (typeof req.body.item.image !== "undefined") {
-        req.item.image = req.body.item.image;
+        if (req.body.item.image.length === 0) {
+          req.item.image = '/placeholder.png'
+        } else {
+          req.item.image = req.body.item.image;
+        }
       }
 
       if (typeof req.body.item.tagList !== "undefined") {


### PR DESCRIPTION
# Description

This fix makes sure the placeholder image is used if there was no image specified on the corresponding item.